### PR TITLE
Enable building sdist, wheel via `python -m build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ bin
 obj
 gen
 build
+dist
 __pycache__

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Logo](docs/hancho_small.png) Hancho
+# ![Logo](https://github.com/aappleby/hancho/blob/main/docs/hancho_small.png?raw=true) Hancho
 
 "班長, hanchō - "Squad leader”, from 19th c. Mandarin 班長 (bānzhǎng, “team leader”)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["poetry-core>=1.9.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "hancho"
+version = "0.0.5"
+description = "A simple, pleasant build system"
+license = "MIT"
+authors = ["aappleby"]
+readme = ["README.md", "docs/README.md"]
+repository = "https://github.com/aappleby/hancho"
+classifiers = [
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Utilities",
+]
+include = [
+    { path = "docs", format = "sdist" },
+    { path = "tests", format = "sdist" },
+    { path = "tutorial", format = "sdist" },
+    { path = "examples", format = "sdist" },
+]
+exclude = ["**/.gitignore"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+
+[tool.poetry.scripts]
+hancho = "hancho:app.main"
+
+[tool.poetry.urls]
+"Additional documentation" = "https://github.com/aappleby/hancho/tree/main/docs#readme"
+"Tutorial" = "https://github.com/aappleby/hancho/tree/main/tutorial#readme"
+"Issue tracker" = "https://github.com/aappleby/hancho/issues"


### PR DESCRIPTION
This PR allows anyone to `python -m build` an sdist or wheel for Hancho.

@aappleby In particular, if you ever decide to put hancho on PyPI, you should be able to use this config as-is.

## Rationale

Making Hancho available on PyPI allows anyone to install and update Hancho via `pip install` or whatever dependency management system they like. This is mainly for people who prefer to keep `hancho.py` in a separate location on their `PATH` separately from their own development tree, and have it updatable via `pip`.

Having a PEP-517-conformant `pyproject.toml` also allows system package maintainers to package Hancho for their distribution with little modification.

## Design

To keep aligned to Hancho’s project mission, this particular `pyproject.toml` is specifically designed to let `hancho.py` remain an independent standalone script in the project root.

In other words, users will still be able to pick just the `hancho.py` file and copy it into their project development tree as-is, without caring about `pyproject.toml` or anything else if they prefer so.

## How to use

To build an sdist and wheel, install PyPA’s [build](https://build.pypa.io/en/stable/) package first.

Then run:

```shell
python -m build
```

To upload the resulting sdist and wheel to PyPI or TestPyPI, use their web front-end or [Twine](https://twine.readthedocs.io/en/latest/).

Or have a GitHub workflow [publish Hancho on PyPI automatically](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) every time you push a Git tag.

## Implementation note

In case you wonder why I choose poetry-core as a build backend:

In contrast to other build backends like setuptools, which would have required `hancho.py` to go in a subdirectory that matches the package name, poetry-core supports building a package from a single-file `*.py` module even if it lives in a project root directly, i.e. next to `pyproject.toml`.

This is to make sure that `hancho.py` remains a portable, self-contained script that doesn’t require PyPI, pip, or anything else, and can be copied as-is anywhere you like.

## Example in the wild

One real-life example of a working system package using the Poetry backend is the `hancho` [AUR package](https://aur.archlinux.org/packages/hancho) ([`PKGBUILD`](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=hancho), [`pyproject.toml`](https://aur.archlinux.org/cgit/aur.git/tree/pyproject.toml.template?h=hancho)).

## Related issue

This PR addresses #1 if you choose so.
