### PR TITLE
hello_world: fix filename

### DIFF
--- a/examples/examples.hancho
+++ b/examples/examples.hancho
@@ -1,6 +1,6 @@
 import hancho
 
-hancho.load("hello_world/hello_world.hancho")
+hancho.load("hello_world/build.hancho")
 hancho.load("hello_gtk/hello_gtk.hancho")
 hancho.load("subrepos/build.hancho")
 


### PR DESCRIPTION
Fix one of the `hancho.load` commands so it no longer references the
non-existing file `hello_world/hello_world.hancho`.
